### PR TITLE
added PEGASUS info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,26 @@ For steps on how to work with this repository [please see documentation here](ht
 
 # Human Rights First Directory
 
-You can find the deployed project at [https://a.humanrightsfirstdocdb.dev/](https://a.humanrightsfirstdocdb.dev/).
+You can find the deployed project at [https://a.humanrightsfirstdocdb.dev/](https://a.humanrightsfirstdocdb.dev/). <br><br>
+
+## Research
+
+Automated document summaries come in many forms.
+- For a broad overview, see these [lecture slides](http://web.stanford.edu/class/cs276b/handouts/lecture14.pdf).
+- Abstractive summaries are feasible with Google's [PEGASUS](https://arxiv.org/pdf/1912.08777.pdf), available in the [repo](https://github.com/google-research/pegasus) and described on [Google's AI blog](https://ai.googleblog.com/2020/06/pegasus-state-of-art-model-for.html). <br><br>
 
 ## Contributors
 
 
 
 
-|[Alex Lucchesi](https://github.com/lucchesia7) 
+[Alex Lucchesi](https://github.com/lucchesia7) 
 [Alyssa Murray](https://github.com/dagtag)  
 [Greg Engelmann](https://github.com/engegreg) 
 [Hunter Jordan](https://github.com/Hunter-Jordan)
 [Peter Rockwood](https://github.com/prockwood)
 [Joshua Aurajo](https://github.com/joshua-aurajo)
+[Mark Porath](https://github.com/m-rath)
 
 
 <br>


### PR DESCRIPTION
## Description

Added a section called "Research" to README.md, just above the "Contributors" section.

Under that Research heading, added two bullets and several links about automated document summarization, an NLP technique that would serve the stakeholder's needs.  Specifically, if the researchers using this app want to see brief summaries of documents before linking to the full text, PEGASUS offers one way to provide those summaries.

PEGASUS provides one type of abstractive summary.  Note that abstractive summaries are not the same as query-specific summaries, which would no doubt prove useful to the researchers, as well.

https://user-images.githubusercontent.com/69127760/139707488-03c58083-d176-4f08-82b6-5e87b49c69ae.mp4

## Type of change

- [x] Research with link to technical tool

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes